### PR TITLE
Feature/ improve log styling

### DIFF
--- a/frontend/medpantry/components/AddToStockForm.tsx
+++ b/frontend/medpantry/components/AddToStockForm.tsx
@@ -85,14 +85,18 @@ export default function AddToStockForm({ extractedSku }: AddToStockFormProps) {
             {boxes ? (
                 boxes.map((baxterBox) => {
                     let localUnitsPacked: number; // Local state for units packed per box
+                    const fullStatus = fullStatusChanged[baxterBox.id] !== undefined
+                        ? fullStatusChanged[baxterBox.id] as boolean
+                        : baxterBox.full;
+
                     return (
-                        <div key={baxterBox.id} className="flex gap-4">
+                        <div key={baxterBox.id} className="flex gap-4 lg:w-1/2 sm:w-full">
                             <BaxterBox
                                 id={baxterBox.id}
                                 sku={baxterBox.sku}
                                 warehouseId={baxterBox.warehouseId}
                                 units={baxterBox.units}
-                                isFull={baxterBox.full}
+                                isFull={fullStatus} // Now passes updated or default full status
                             />
                             <div className='flex flex-col gap-4'>
                                 <form onSubmit={(e) => handleBoxSubmit(e, localUnitsPacked, baxterBox.id)} className="flex flex-col gap-4">

--- a/frontend/medpantry/components/BaxterBox.tsx
+++ b/frontend/medpantry/components/BaxterBox.tsx
@@ -16,15 +16,29 @@ interface BaxterBoxProps {
 export default function BaxterBox({ warehouseId, id, sku, units, isFull, bgColor = 'bg-secondary' }: BaxterBoxProps) {
 
   return (  
-    <div className={`${bgColor} border-solid border-border rounded-md p-4 flex flex-col gap-2`}>
-      <h1 className='sm:text-lg md:text-xl lg:text-2xl font-bold'>Baxter Box #{id}</h1>
+    <div className={`bg-card-foreground border-solid border-border rounded-md p-4 flex flex-col gap-2 w-full`}>
+      <div className="flex justify-between">
+        <h1 className='sm:text-lg md:text-xl lg:text-2xl font-bold'>Baxter Box</h1>
+        <h1 className="sm:text-lg md:text-xl lg:text-2xl font-bold text-gray-400">#{id}</h1>
+      </div>
+
       <h2 className={`sm:text-sm md:text-md lg:text-lg font-bold ${isFull ? 'text-red-500' : 'text-green-500'}`}>
           {isFull ? 'Full' : 'Not full'}
       </h2>
-      <h2 className='sm:text-sm md:text-md lg:text-lg'>{units} units</h2>
-      <div>
-          <h2 className='sm:text-sm md:text-md lg:text-lg'>Contains  SKU#{sku}</h2>
-          <h2 className='sm:text-sm md:text-md lg:text-lg'>Located in Warehouse {warehouseId}</h2>
+
+      <div className="flex justify-between">
+                <p>Units</p>
+                <p className="text-gray-400">{units}</p>
+      </div>
+
+      <div className="flex justify-between">
+                <p>SKU</p>
+                <p className="text-gray-400">{sku}</p>
+      </div>
+
+      <div className="flex justify-between">
+                <p>Located in Warehouse</p>
+                <p className="text-gray-400">#{warehouseId}</p>
       </div>
     </div>
   );

--- a/frontend/medpantry/components/LogEntry.tsx
+++ b/frontend/medpantry/components/LogEntry.tsx
@@ -43,7 +43,7 @@ export default function LogEntry({ id, box, sku, proposedQuantityToAdd, fullStat
     };
 
     return (
-        <div className="bg-secondary border-solid border-border rounded-md p-4 flex flex-col gap-2">
+        <div className="bg-card-foreground border-solid border-border rounded-md p-4 flex flex-col gap-2 w-1/2">
             <h1 className="font-bold text-xl">Stock Update</h1>
 
             <div className="flex justify-between">
@@ -70,7 +70,7 @@ export default function LogEntry({ id, box, sku, proposedQuantityToAdd, fullStat
 
             <Separator />
 
-            <div className="flex gap-4">
+            <div className="flex gap-4 justify-between">
                 <Button className="bg-green-500" onClick={handleAccept}>Accept</Button>
                 <Button className="bg-red-500" onClick={handleReject}>Reject</Button>
             </div>


### PR DESCRIPTION
In order to present an updating view to Martin, I have set the background of manager log entries to a more updated colour and changed the general sizing/styling.

Note this is not final, as we still need to take into account completed orders.

<img width="785" alt="image" src="https://github.com/user-attachments/assets/93120d02-85eb-48fe-ac99-856f324c90c4">
