### PR TITLE
Bugfix/Auto refresh page on manager log change

### DIFF
--- a/frontend/medpantry/components/LogEntry.tsx
+++ b/frontend/medpantry/components/LogEntry.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { Button } from "./ui/button";
 import { Separator } from "./ui/separator";
+import { useRouter } from "next/navigation";
 
 interface LogEntryProps {
     id: number;
@@ -14,6 +15,8 @@ interface LogEntryProps {
 
 export default function LogEntry({ id, box, sku, proposedQuantityToAdd, fullStatusChangedTo }: LogEntryProps) {
 
+    const router = useRouter();
+
     const handleAccept = async () => {
         try {
             const res = await fetch(`/api/resolveStockChange?id=${id}&accepted=true`, {
@@ -23,6 +26,7 @@ export default function LogEntry({ id, box, sku, proposedQuantityToAdd, fullStat
                 },
             });
             if (!res.ok) throw new Error('Network response was not ok');
+            router.refresh()
         } catch (error) {
             console.error('Error in accepting:', error);
         }
@@ -37,6 +41,7 @@ export default function LogEntry({ id, box, sku, proposedQuantityToAdd, fullStat
                 },
             });
             if (!res.ok) throw new Error('Network response was not ok');
+            router.refresh()
         } catch (error) {
             console.error('Error in rejecting:', error);
         }

--- a/frontend/medpantry/components/ManagerLog.tsx
+++ b/frontend/medpantry/components/ManagerLog.tsx
@@ -27,7 +27,6 @@ export default async function ManagerLog({} : props) {
         console.error(error);
         return null;
       }
-    
 
       return (
         <>


### PR DESCRIPTION
Page now just auto refreshes when a log entry is accepted/rejected so that it doesn't keep showing on the list 