### PR TITLE
Hotfix/Clear gradle cache before building

### DIFF
--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -22,6 +22,10 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
+      # Clear the Gradle cache
+      - name: Clear Gradle cache
+        run: rm -rf $HOME/.gradle/caches
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
       - name: Build with Gradle


### PR DESCRIPTION
Remove existing build caches to prompt github action to use a fresh build each time, trying to fix the issue where the deployed backend isn't taking latest changes.